### PR TITLE
Issue #6: block task_id path traversal in snapshot paths

### DIFF
--- a/team-chat/scripts/protocol.py
+++ b/team-chat/scripts/protocol.py
@@ -96,6 +96,13 @@ def validate_message(message: dict[str, Any]) -> None:
             field_name=f"message.{endpoint}",
         )
 
+    task_id = message.get("task_id")
+    if task_id is not None:
+        message["task_id"] = validate_identifier(
+            task_id,
+            field_name="message.task_id",
+        )
+
     if not isinstance(message.get("payload"), dict):
         raise ValueError("message.payload must be an object")
 

--- a/team-chat/scripts/service.py
+++ b/team-chat/scripts/service.py
@@ -478,6 +478,11 @@ class TeamChatService:
         task_id = message.get("task_id")
         if not isinstance(task_id, str) or not task_id:
             return
+        try:
+            task_id = validate_identifier(task_id, field_name="task_id")
+        except ValueError:
+            # Keep rehydrate resilient to malformed historical data.
+            return
 
         payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
         created_at = message.get("created_at") or utc_now_iso()

--- a/team-chat/scripts/storage.py
+++ b/team-chat/scripts/storage.py
@@ -371,11 +371,13 @@ class TeamStore:
         return records
 
     def write_task_snapshot(self, task_id: str, payload: dict[str, Any]) -> None:
-        path = self.tasks_dir / f"{task_id}.json"
+        safe_task_id = validate_identifier(task_id, field_name="task_id")
+        path = self.tasks_dir / f"{safe_task_id}.json"
         self.write_json_atomic(path, payload)
 
     def read_task_snapshot(self, task_id: str) -> dict[str, Any] | None:
-        path = self.tasks_dir / f"{task_id}.json"
+        safe_task_id = validate_identifier(task_id, field_name="task_id")
+        path = self.tasks_dir / f"{safe_task_id}.json"
         if not path.exists():
             return None
         snapshot = self.read_json(path, None)


### PR DESCRIPTION
## Summary
Fixes the `task_id` path traversal vulnerability by enforcing identifier validation before any snapshot path usage.

Fixes #6.

## Design (minimal safe)
- Validate `message.task_id` in protocol validation (same safety rule as `team/from/to/agent`).
- Add defense-in-depth validation in storage snapshot read/write path (`task_id` must be safe identifier).
- Keep `rehydrate` resilient: malformed historical `task_id` records are ignored for snapshot projection instead of crashing.

## Behavior changes
- `send()` now rejects traversal-like `task_id` (e.g. `../../escape`) with `ValueError`.
- Snapshot path build cannot escape `teams/<team>/tasks/`.

## Tests
- Added `test_rejects_task_id_path_traversal`.
- Added `test_rehydrate_ignores_malformed_task_id_snapshot_update`.
- Full suite passes:
  - `python3 -m unittest discover -s tests -v` (15 passed)
