### PR TITLE
Issue #10: clean CLI error for missing --payload-file

### DIFF
--- a/team-chat/scripts/main.py
+++ b/team-chat/scripts/main.py
@@ -20,7 +20,10 @@ def _parse_payload(args: argparse.Namespace) -> dict:
         return json.loads(args.payload_json)
     if args.payload_file:
         path = Path(args.payload_file)
-        return json.loads(path.read_text(encoding="utf-8"))
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise ValueError(f"payload file not found: {path}") from exc
     return {}
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+CLI_PATH = Path(__file__).resolve().parents[1] / "team-chat" / "scripts" / "main.py"
+
+
+def _run_cli(data_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), "--data-root", str(data_root), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TeamChatCliTests(unittest.TestCase):
+    def test_missing_payload_file_returns_clean_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            init = _run_cli(root, "init", "demo", "--members", "lead,ops")
+            self.assertEqual(0, init.returncode, init.stderr)
+
+            missing_file = root / "no-such-payload.json"
+            result = _run_cli(
+                root,
+                "send",
+                "demo",
+                "--from",
+                "ops",
+                "--to",
+                "lead",
+                "--type",
+                "handoff",
+                "--payload-file",
+                str(missing_file),
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("error: payload file not found:", result.stderr)
+            self.assertIn(str(missing_file), result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_existing_value_error_path_stays_readable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            init = _run_cli(root, "init", "demo", "--members", "lead,dev")
+            self.assertEqual(0, init.returncode, init.stderr)
+
+            result = _run_cli(
+                root,
+                "send",
+                "demo",
+                "--from",
+                "../ops",
+                "--to",
+                "dev",
+                "--type",
+                "handoff",
+                "--payload-json",
+                "{}",
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("error:", result.stderr)
+            self.assertIn("message.from", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Improve CLI UX for missing `--payload-file` by returning a clean user-facing error instead of a Python traceback.

Fixes #10.

## Scope
- Minimal change in `team-chat/scripts/main.py`:
  - Catch `FileNotFoundError` when reading `--payload-file`
  - Re-raise as `ValueError("payload file not found: ...")`
- Existing CLI error handling path remains (`error: ...`, non-zero exit code).

## Tests
- Added `tests/test_cli.py`:
  - `test_missing_payload_file_returns_clean_error`
  - `test_existing_value_error_path_stays_readable`

## Validation
- `python3 -m unittest discover -s tests -v`
- Result: 17 passed
