### PR TITLE
feat: add malformed JSONL diagnostics for ops observability

### DIFF
--- a/team-chat/scripts/main.py
+++ b/team-chat/scripts/main.py
@@ -185,6 +185,18 @@ def cmd_status(args: argparse.Namespace) -> int:
             f"- {msg.get('id')} to={msg.get('to')} type={msg.get('type')} "
             f"created={iso_to_local_string(msg.get('created_at', ''))} age_min={age}"
         )
+
+    diagnostics = result.get("malformed_jsonl", {})
+    malformed_total = int(diagnostics.get("total", 0)) if isinstance(diagnostics, dict) else 0
+    print(f"malformed_jsonl_total: {malformed_total}")
+    if isinstance(diagnostics, dict):
+        for item in diagnostics.get("files", []):
+            if not isinstance(item, dict):
+                continue
+            print(
+                f"- {item.get('path')}: count={item.get('count', 0)} "
+                f"last_line={item.get('last_line')} last_reason={item.get('last_reason')}"
+            )
     return 0
 
 

--- a/team-chat/scripts/service.py
+++ b/team-chat/scripts/service.py
@@ -313,6 +313,7 @@ class TeamChatService:
                 stale_tasks.append(task)
 
         stale_messages = store.stale_unread_messages(stale_seconds)
+        malformed_jsonl = store.malformed_jsonl_diagnostics()
 
         return {
             "team": team,
@@ -321,6 +322,7 @@ class TeamChatService:
             "blocked_tasks": blocked_tasks,
             "stale_tasks": stale_tasks,
             "stale_messages": stale_messages,
+            "malformed_jsonl": malformed_jsonl,
             "task_count": len(snapshots),
         }
 


### PR DESCRIPTION
## Summary
Fixes #8 by making malformed JSONL handling observable while preserving non-strict behavior.

### What changed
- Added malformed-record diagnostics in storage reads:
  - `read_jsonl`
  - `_iter_jsonl_reverse`
  - `_read_jsonl_record_at_offset`
- Malformed diagnostics are persisted in `teams/<team>/state/malformed-jsonl.json` with:
  - unique malformed counter (deduplicated by line fingerprint)
  - per-file counts
  - last seen line and reason
- Added optional warning output via env var:
  - `TEAM_CHAT_WARN_MALFORMED=1`
  - emits `warning: malformed jsonl skipped ...` to stderr on first-seen malformed records
- Exposed malformed counters in service status (`malformed_jsonl`) and CLI text output:
  - `malformed_jsonl_total: <n>`
  - per-file diagnostic lines
- Backward compatibility preserved:
  - malformed lines are still skipped (no crash / no strict-mode behavior introduced)

## Tests
- `python3 -m unittest discover -s tests -v` (21 passed)
- Added tests:
  - `test_malformed_jsonl_diagnostics_are_counted_and_deduplicated`
  - `test_status_shows_malformed_counter_and_optional_warning`
