### PR TITLE
fix: data-root auto-detection + add skipped task status

### DIFF
--- a/team-chat/scripts/main.py
+++ b/team-chat/scripts/main.py
@@ -10,8 +10,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from protocol import MESSAGE_TYPES
-from repo_root import get_repo_root
+from protocol import MESSAGE_TYPES, TASK_STATUSES
+from repo_root import detect_data_root
 from service import TeamChatService, human_age_minutes, iso_to_local_string
 
 
@@ -261,8 +261,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="team-chat file-backed control-plane CLI")
     parser.add_argument(
         "--data-root",
-        default=str(get_repo_root()),
-        help="Repository root where teams/<team>/ state is stored",
+        default=str(detect_data_root()),
+        help=(
+            "Repository root where teams/<team>/ state is stored. "
+            "Auto-detected from $TEAM_CHAT_DATA_ROOT, or by walking up from "
+            "cwd looking for teams/, AGENTS.md, or .agent/"
+        ),
     )
     parser.add_argument("--json", action="store_true", help="Output JSON")
 
@@ -307,7 +311,7 @@ def build_parser() -> argparse.ArgumentParser:
     update_parser.add_argument("--from", dest="sender", required=True)
     update_parser.add_argument("--to", dest="recipient", required=True)
     update_parser.add_argument("--task-id", required=True)
-    update_parser.add_argument("--status")
+    update_parser.add_argument("--status", choices=sorted(TASK_STATUSES))
     update_parser.add_argument("--progress")
     update_parser.add_argument("--eta")
     blocked_group = update_parser.add_mutually_exclusive_group()

--- a/team-chat/scripts/protocol.py
+++ b/team-chat/scripts/protocol.py
@@ -26,6 +26,13 @@ MESSAGE_TYPES = {
 }
 
 PRIORITIES = {"low", "normal", "high", "critical"}
+TASK_STATUSES = {
+    "assigned",
+    "in_progress",
+    "blocked",
+    "done",
+    "skipped",
+}
 IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 

--- a/team-chat/scripts/repo_root.py
+++ b/team-chat/scripts/repo_root.py
@@ -47,6 +47,49 @@ def _openclaw_workspace_from_path(path: Path) -> Optional[Path]:
     return None
 
 
+def _walk_up_for_data_root(start: Path) -> Optional[Path]:
+    """Walk up from *start* looking for a directory that looks like a data root.
+
+    A directory qualifies when it contains at least one of:
+    - a ``teams/`` subdirectory
+    - an ``AGENTS.md`` file
+    - a ``.agent/`` directory
+    """
+    current = start.resolve()
+    # Guard against symlink loops by capping iterations at a generous depth.
+    for _ in range(256):
+        if (current / "teams").is_dir():
+            return current
+        if (current / "AGENTS.md").is_file():
+            return current
+        if (current / ".agent").is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def detect_data_root() -> Path:
+    """Auto-detect the data root directory.
+
+    Resolution order:
+    1. ``TEAM_CHAT_DATA_ROOT`` environment variable (highest priority).
+    2. Walk up from cwd looking for ``teams/``, ``AGENTS.md``, or ``.agent/``.
+    3. Fall back to :func:`get_repo_root` (git / OpenClaw heuristics).
+    """
+    env_data_root = os.environ.get("TEAM_CHAT_DATA_ROOT")
+    if env_data_root:
+        return Path(env_data_root).expanduser()
+
+    walked = _walk_up_for_data_root(Path.cwd())
+    if walked is not None:
+        return walked
+
+    return get_repo_root()
+
+
 def get_repo_root() -> Path:
     # Prefer an explicit env override for cron/agents.
     repo_root_env = os.environ.get("REPO_ROOT")


### PR DESCRIPTION
## Summary

- **Issue #30 — data-root auto-detection**: Added `detect_data_root()` in `repo_root.py` which checks `$TEAM_CHAT_DATA_ROOT` env var first, then walks up from cwd looking for `teams/`, `AGENTS.md`, or `.agent/` directories, falling back to the existing `get_repo_root()` git/OpenClaw heuristics. Updated the CLI `--data-root` default and help text accordingly.
- **Issue #31 — add 'skipped' status**: Added `TASK_STATUSES` constant in `protocol.py` (`assigned`, `in_progress`, `blocked`, `done`, `skipped`) and wired `choices=sorted(TASK_STATUSES)` on the `task-update --status` CLI argument.

Closes #30
Closes #31

## Test plan

- [x] All 32 existing tests pass (`python3 -m unittest discover -s tests -v`)
- [ ] Verify `--data-root` auto-detects correctly from a subdirectory of a workspace with `teams/`
- [ ] Verify `TEAM_CHAT_DATA_ROOT=/some/path` overrides all other detection
- [ ] Verify `task-update --status skipped` is accepted by the CLI
- [ ] Verify `task-update --status invalid` is rejected by argparse

🤖 Generated with [Claude Code](https://claude.com/claude-code)